### PR TITLE
Add Client table first and last page buttons

### DIFF
--- a/src/components/ClientTable/ClientTable.spec.tsx
+++ b/src/components/ClientTable/ClientTable.spec.tsx
@@ -1,7 +1,6 @@
-import { randomInt, range } from '@douglasneuroinformatics/libjs';
+import { range } from '@douglasneuroinformatics/libjs';
 import { render, screen } from '@testing-library/react';
-import { userEvent } from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { ClientTable } from './ClientTable';
 import { type ClientTableColumn } from './ClientTable';

--- a/src/components/ClientTable/ClientTable.spec.tsx
+++ b/src/components/ClientTable/ClientTable.spec.tsx
@@ -1,0 +1,86 @@
+import { randomInt, range } from '@douglasneuroinformatics/libjs';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ClientTable } from './ClientTable';
+import { type ClientTableColumn } from './ClientTable';
+
+type ExampleItem = {
+  c1: number;
+  c2: number;
+  c3: number;
+  c4: number;
+  c5: number;
+  c6: number;
+  c7: number;
+  c8: number;
+  c9: number;
+  c10: number;
+  c11: number;
+  c12: number;
+  c13: number;
+  c14: number;
+  c15: number;
+  id: string;
+};
+
+const columns: ClientTableColumn<ExampleItem>[] = [
+  {
+    field: 'id',
+    label: 'ID'
+  }
+];
+
+for (let i = 1; i < 16; i++) {
+  columns.push({
+    field: `c${i}` as keyof ExampleItem,
+    label: `Column ${i}`
+  });
+}
+
+const TEST_ID = 'ClientTable';
+
+describe('ClientTable', () => {
+  it('should render', () => {
+    render(
+      <ClientTable
+        columnDropdownOptions={[
+          {
+            label: 'Delete',
+            onSelection: (column) => {
+              return column.label;
+            }
+          }
+        ]}
+        columns={[
+          {
+            field: 'f1',
+            label: 'Field 1'
+          },
+          {
+            field: 'f2',
+            label: 'Field 2'
+          },
+          {
+            field: 'f3',
+            label: 'Field 3'
+          }
+        ]}
+        data={[
+          {
+            f1: 1,
+            f2: range(1000).join(', '),
+            f3: 3
+          }
+        ]}
+        minRows={10}
+        noWrap={true}
+        onEntryClick={(entry) => {
+          return entry;
+        }}
+      />
+    );
+    expect(screen.getByTestId(TEST_ID)).toBeInTheDocument();
+  });
+});

--- a/src/components/ClientTable/ClientTable.spec.tsx
+++ b/src/components/ClientTable/ClientTable.spec.tsx
@@ -11,11 +11,15 @@ const LAST_BUTTON_ID = 'last-page-button';
 
 describe('ClientTable', () => {
   it('should render', () => {
-    render(<ClientTable columns={[]} data={[]} minRows={10} noWrap={true} />);
+    render(<ClientTable columns={[]} data={[]} minRows={10} />);
     expect(screen.getByTestId(TEST_ID)).toBeInTheDocument();
     expect(screen.getByTestId(FIRST_BUTTON_ID)).toBeInTheDocument();
     expect(screen.getByTestId(PREVIOUS_BUTTON_ID)).toBeInTheDocument();
     expect(screen.getByTestId(NEXT_BUTTON_ID)).toBeInTheDocument();
     expect(screen.getByTestId(LAST_BUTTON_ID)).toBeInTheDocument();
+  });
+  it('should contain a custom class name', () => {
+    render(<ClientTable className="foo" columns={[]} data={[]} minRows={10} />);
+    expect(screen.getByTestId(TEST_ID)).toHaveClass('foo');
   });
 });

--- a/src/components/ClientTable/ClientTable.spec.tsx
+++ b/src/components/ClientTable/ClientTable.spec.tsx
@@ -1,51 +1,21 @@
-import { range } from '@douglasneuroinformatics/libjs';
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
 import { ClientTable } from './ClientTable';
 
 const TEST_ID = 'ClientTable';
+const FIRST_BUTTON_ID = 'first-page-button';
+const PREVIOUS_BUTTON_ID = 'previous-page-button';
+const NEXT_BUTTON_ID = 'next-page-button';
+const LAST_BUTTON_ID = 'last-page-button';
 
 describe('ClientTable', () => {
   it('should render', () => {
-    render(
-      <ClientTable
-        columnDropdownOptions={[
-          {
-            label: 'Delete',
-            onSelection: (column) => {
-              return column.label;
-            }
-          }
-        ]}
-        columns={[
-          {
-            field: 'f1',
-            label: 'Field 1'
-          },
-          {
-            field: 'f2',
-            label: 'Field 2'
-          },
-          {
-            field: 'f3',
-            label: 'Field 3'
-          }
-        ]}
-        data={[
-          {
-            f1: 1,
-            f2: range(1000).join(', '),
-            f3: 3
-          }
-        ]}
-        minRows={10}
-        noWrap={true}
-        onEntryClick={(entry) => {
-          return entry;
-        }}
-      />
-    );
+    render(<ClientTable columns={[]} data={[]} minRows={10} noWrap={true} />);
     expect(screen.getByTestId(TEST_ID)).toBeInTheDocument();
+    expect(screen.getByTestId(FIRST_BUTTON_ID)).toBeInTheDocument();
+    expect(screen.getByTestId(PREVIOUS_BUTTON_ID)).toBeInTheDocument();
+    expect(screen.getByTestId(NEXT_BUTTON_ID)).toBeInTheDocument();
+    expect(screen.getByTestId(LAST_BUTTON_ID)).toBeInTheDocument();
   });
 });

--- a/src/components/ClientTable/ClientTable.spec.tsx
+++ b/src/components/ClientTable/ClientTable.spec.tsx
@@ -3,40 +3,6 @@ import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
 import { ClientTable } from './ClientTable';
-import { type ClientTableColumn } from './ClientTable';
-
-type ExampleItem = {
-  c1: number;
-  c2: number;
-  c3: number;
-  c4: number;
-  c5: number;
-  c6: number;
-  c7: number;
-  c8: number;
-  c9: number;
-  c10: number;
-  c11: number;
-  c12: number;
-  c13: number;
-  c14: number;
-  c15: number;
-  id: string;
-};
-
-const columns: ClientTableColumn<ExampleItem>[] = [
-  {
-    field: 'id',
-    label: 'ID'
-  }
-];
-
-for (let i = 1; i < 16; i++) {
-  columns.push({
-    field: `c${i}` as keyof ExampleItem,
-    label: `Column ${i}`
-  });
-}
 
 const TEST_ID = 'ClientTable';
 

--- a/src/components/ClientTable/ClientTable.tsx
+++ b/src/components/ClientTable/ClientTable.tsx
@@ -85,7 +85,7 @@ export const ClientTable = <T extends ClientTableEntry>({
   const nRows = Math.max(currentEntries.length, minRows ?? -1);
 
   return (
-    <div className={className} {...props}>
+    <div className={className} {...props} data-testid="ClientTable">
       <div className="rounded-md border bg-card tracking-tight text-muted-foreground shadow-sm">
         <Table>
           <Table.Header>

--- a/src/components/ClientTable/ClientTablePagination.tsx
+++ b/src/components/ClientTable/ClientTablePagination.tsx
@@ -19,6 +19,7 @@ export const ClientTablePagination = ({
   setCurrentPage,
   totalEntries
 }: ClientPagePaginationProps) => {
+  console.log(pageCount);
   const { t } = useTranslation('libui');
   return (
     <div className="flex items-center justify-between py-3">
@@ -26,6 +27,16 @@ export const ClientTablePagination = ({
         <p className="text-sm font-medium text-muted-foreground">{`${firstEntry} - ${lastEntry} / ${totalEntries}`}</p>
       </div>
       <div className="flex flex-1 justify-between gap-3 sm:justify-end">
+        <Button
+          disabled={currentPage === 1}
+          type="button"
+          variant="outline"
+          onClick={() => {
+            setCurrentPage(1);
+          }}
+        >
+          {t('pagination.firstPage')}
+        </Button>
         <Button
           disabled={currentPage === 1}
           type="button"
@@ -45,6 +56,16 @@ export const ClientTablePagination = ({
           }}
         >
           {t('pagination.next')}
+        </Button>
+        <Button
+          disabled={currentPage === pageCount}
+          type="button"
+          variant="outline"
+          onClick={() => {
+            setCurrentPage(pageCount);
+          }}
+        >
+          {t('pagination.lastPage')}
         </Button>
       </div>
     </div>

--- a/src/components/ClientTable/ClientTablePagination.tsx
+++ b/src/components/ClientTable/ClientTablePagination.tsx
@@ -27,6 +27,7 @@ export const ClientTablePagination = ({
       </div>
       <div className="flex flex-1 justify-between gap-3 sm:justify-end">
         <Button
+          data-testid="first-page-button"
           disabled={currentPage === 1}
           type="button"
           variant="outline"
@@ -37,6 +38,7 @@ export const ClientTablePagination = ({
           {t('pagination.firstPage')}
         </Button>
         <Button
+          data-testid="previous-page-button"
           disabled={currentPage === 1}
           type="button"
           variant="outline"
@@ -47,6 +49,7 @@ export const ClientTablePagination = ({
           {t('pagination.previous')}
         </Button>
         <Button
+          data-testid="next-page-button"
           disabled={currentPage === pageCount}
           type="button"
           variant="outline"
@@ -57,6 +60,7 @@ export const ClientTablePagination = ({
           {t('pagination.next')}
         </Button>
         <Button
+          data-testid="last-page-button"
           disabled={currentPage === pageCount}
           type="button"
           variant="outline"

--- a/src/components/ClientTable/ClientTablePagination.tsx
+++ b/src/components/ClientTable/ClientTablePagination.tsx
@@ -19,7 +19,6 @@ export const ClientTablePagination = ({
   setCurrentPage,
   totalEntries
 }: ClientPagePaginationProps) => {
-  console.log(pageCount);
   const { t } = useTranslation('libui');
   return (
     <div className="flex items-center justify-between py-3">

--- a/src/i18n/translations/libui.json
+++ b/src/i18n/translations/libui.json
@@ -143,6 +143,14 @@
     "previous": {
       "en": "Previous",
       "fr": "Précédent"
+    },
+    "firstPage": {
+      "en": "First",
+      "fr": "Première"
+    },
+    "lastPage": {
+      "en": "Last",
+      "fr": "Dernière"
     }
   },
   "searchBar": {

--- a/src/i18n/translations/libui.json
+++ b/src/i18n/translations/libui.json
@@ -145,12 +145,12 @@
       "fr": "Précédent"
     },
     "firstPage": {
-      "en": "First",
-      "fr": "Première"
+      "en": "<< First",
+      "fr": "<< Première"
     },
     "lastPage": {
-      "en": "Last",
-      "fr": "Dernière"
+      "en": "Last >>",
+      "fr": "Dernière >>"
     }
   },
   "searchBar": {


### PR DESCRIPTION
closes issue #48 

Allows users to go to the first page or the last page of the client table data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced "First Page" and "Last Page" navigation buttons on the client table, enabling quick jumps to the beginning or end of the dataset.
  - Added localized labels for these buttons in English and French for an improved user experience.
  
- **Tests**
  - Introduced a new test suite for the `ClientTable` component to ensure correct rendering and functionality.
  
- **Enhancements**
  - Added a data attribute for easier targeting of the `ClientTable` component in testing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->