### PR TITLE
feat: support zod v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "tailwindcss": "^4.1.0",
-    "zod": "^3.23.6"
+    "zod": "^3.25.x"
   },
   "dependencies": {
     "@douglasneuroinformatics/libjs": "^2.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
     dependencies:
       '@douglasneuroinformatics/libjs':
         specifier: ^2.8.0
-        version: 2.8.0(neverthrow@8.2.0)(zod@3.24.2)
+        version: 2.8.0(neverthrow@8.2.0)(zod@3.25.32)
       '@douglasneuroinformatics/libui-form-types':
         specifier: ^0.11.0
         version: 0.11.0
@@ -137,8 +137,8 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       zod:
-        specifier: ^3.23.6
-        version: 3.24.2
+        specifier: ^3.25.x
+        version: 3.25.32
       zustand:
         specifier: ^5.0.3
         version: 5.0.3(@types/react@19.0.12)(react@19.1.0)
@@ -6327,9 +6327,9 @@ packages:
       { integrity: sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ== }
     engines: { node: '>=18' }
 
-  zod@3.24.2:
+  zod@3.25.32:
     resolution:
-      { integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ== }
+      { integrity: sha512-OSm2xTIRfW8CV5/QKgngwmQW/8aPfGdaQFlrGoErlgg/Epm7cjb6K6VEyExfe65a3VybUOnu381edLb0dfJl0g== }
 
   zustand@5.0.3:
     resolution:
@@ -6603,7 +6603,7 @@ snapshots:
       - svelte
       - ts-node
 
-  '@douglasneuroinformatics/libjs@2.8.0(neverthrow@8.2.0)(zod@3.24.2)':
+  '@douglasneuroinformatics/libjs@2.8.0(neverthrow@8.2.0)(zod@3.25.32)':
     dependencies:
       clean-stack: 5.2.0
       extract-stack: 3.0.0
@@ -6611,7 +6611,7 @@ snapshots:
       serialize-error: 12.0.0
       stringify-object: 5.0.0
       type-fest: 4.39.0
-      zod: 3.24.2
+      zod: 3.25.32
 
   '@douglasneuroinformatics/libui-form-types@0.11.0':
     dependencies:
@@ -11607,7 +11607,7 @@ snapshots:
 
   yoctocolors@2.1.1: {}
 
-  zod@3.24.2: {}
+  zod@3.25.32: {}
 
   zustand@5.0.3(@types/react@19.0.12)(react@19.1.0):
     optionalDependencies:

--- a/src/components/Form/Form.stories.tsx
+++ b/src/components/Form/Form.stories.tsx
@@ -7,10 +7,12 @@ import type { FormFields } from '@douglasneuroinformatics/libui-form-types';
 import type FormTypes from '@douglasneuroinformatics/libui-form-types';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { IntRange } from 'type-fest';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 import { Heading } from '../Heading';
 import { Form } from './Form';
+
+import type { ZodTypeLike } from './types';
 
 const DISABLED = false;
 
@@ -49,7 +51,7 @@ const $ExampleFormData = z.object({
   stringRadio: z.enum(['a', 'b', 'c']).optional()
 });
 type ExampleFormSchemaType = typeof $ExampleFormData;
-type ExampleFormData = z.TypeOf<typeof $ExampleFormData>;
+type ExampleFormData = z.infer<typeof $ExampleFormData>;
 
 const $SimpleExampleFormData = z.object({
   name: z.string()
@@ -513,7 +515,7 @@ export const WithPreventReset: StoryObj<typeof Form<SimpleExampleFormSchemaType>
   }
 };
 
-export const WithSuspend: StoryObj<typeof Form<z.ZodType<FormTypes.Data>, { delay?: number }>> = {
+export const WithSuspend: StoryObj<typeof Form<ZodTypeLike<FormTypes.Data>, { delay?: number }>> = {
   args: {
     content: {
       delay: {

--- a/src/components/Form/Form.test.tsx
+++ b/src/components/Form/Form.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Mock } from 'vitest';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 import { Form } from './Form';
 

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -10,7 +10,6 @@ import type {
 import { get, set } from 'lodash-es';
 import { twMerge } from 'tailwind-merge';
 import type { Promisable } from 'type-fest';
-import { z } from 'zod';
 
 import { useTranslation } from '@/hooks';
 import { cn } from '@/utils';
@@ -22,9 +21,9 @@ import { ErrorMessage } from './ErrorMessage';
 import { FieldsComponent } from './FieldsComponent';
 import { getInitialValues } from './utils';
 
-import type { FormErrors } from './types';
+import type { FormErrors, ZodErrorLike, ZodTypeLike } from './types';
 
-type FormProps<TSchema extends z.ZodType<FormDataType>, TData extends z.TypeOf<TSchema> = z.TypeOf<TSchema>> = {
+type FormProps<TSchema extends ZodTypeLike<FormDataType>, TData extends TSchema['_input'] = TSchema['_input']> = {
   [key: `data-${string}`]: unknown;
   additionalButtons?: {
     left?: React.ReactNode;
@@ -42,7 +41,7 @@ type FormProps<TSchema extends z.ZodType<FormDataType>, TData extends z.TypeOf<T
   onBeforeSubmit?:
     | ((data: NoInfer<TData>) => Promisable<{ errorMessage: string; success: false } | { success: true }>)
     | null;
-  onError?: (error: z.ZodError<NoInfer<TData>>) => void;
+  onError?: (error: ZodErrorLike) => void;
   onSubmit: (data: NoInfer<TData>) => Promisable<void>;
   preventResetValuesOnReset?: boolean;
   readOnly?: boolean;
@@ -50,10 +49,10 @@ type FormProps<TSchema extends z.ZodType<FormDataType>, TData extends z.TypeOf<T
   revalidateOnBlur?: boolean;
   submitBtnLabel?: string;
   suspendWhileSubmitting?: boolean;
-  validationSchema: z.ZodType<TData>;
+  validationSchema: ZodTypeLike<TData>;
 };
 
-const Form = <TSchema extends z.ZodType<FormDataType>, TData extends z.TypeOf<TSchema> = z.TypeOf<TSchema>>({
+const Form = <TSchema extends ZodTypeLike<FormDataType>, TData extends TSchema['_input'] = TSchema['_input']>({
   additionalButtons,
   className,
   content,
@@ -81,7 +80,7 @@ const Form = <TSchema extends z.ZodType<FormDataType>, TData extends z.TypeOf<TS
   );
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const handleError = (error: z.ZodError<TData>) => {
+  const handleError = (error: ZodErrorLike) => {
     const fieldErrors: FormErrors<TData> = {};
     const rootErrors: string[] = [];
     for (const issue of error.issues) {

--- a/src/components/Form/types.ts
+++ b/src/components/Form/types.ts
@@ -25,3 +25,36 @@ export type BaseFieldComponentProps<TValue extends FormFieldValue = FormFieldVal
 export type FormErrors<TData extends FormDataType = FormDataType> = {
   [K in keyof TData]?: FieldError<TData[K]>;
 };
+
+export type ZodIssueLike = {
+  [key: string]: any;
+  readonly code: string;
+  readonly message: string;
+  readonly path: PropertyKey[];
+};
+
+export type ZodErrorLike = {
+  cause?: unknown;
+  issues: ZodIssueLike[];
+  name: string;
+};
+
+export type ZodSafeParseResultLike<T> = ZodSafeParseErrorLike | ZodSafeParseSuccessLike<T>;
+
+export type ZodSafeParseSuccessLike<TOutput> = {
+  data: TOutput;
+  error?: never;
+  success: true;
+};
+
+export type ZodSafeParseErrorLike = {
+  data?: never;
+  error: ZodErrorLike;
+  success: false;
+};
+
+export type ZodTypeLike<TOutput, TInput = TOutput> = {
+  readonly _input: TInput;
+  readonly _output: TOutput;
+  safeParseAsync: (data: unknown) => Promise<ZodSafeParseResultLike<TOutput>>;
+};


### PR DESCRIPTION
The form now supports both Zod v3 and Zod v4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated form components to use more generic, abstracted schema validation types instead of direct dependencies on a specific validation library.
  - Adjusted type annotations and imports to improve flexibility for future validation implementations.

- **Chores**
  - Broadened the supported version range for a peer dependency, allowing compatibility with newer patch versions. 

- **Tests**
  - Updated test imports to align with the new schema validation import paths.

- **New Features**
  - Introduced new type definitions to model validation errors and parsing results, enhancing type safety and extensibility for form validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->