### PR TITLE
fix: recreate t function when resolved language changes

### DIFF
--- a/src/hooks/useTranslation/useTranslation.ts
+++ b/src/hooks/useTranslation/useTranslation.ts
@@ -28,7 +28,7 @@ export function useTranslation(namespace?: TranslationNamespace): TranslatorType
       changeLanguage: i18n.changeLanguage.bind(i18n),
       t
     };
-  }, []);
+  }, [resolvedLanguage]);
 
   useEffect(() => {
     i18n.addEventListener('languageChange', setResolvedLanguage);


### PR DESCRIPTION
Create new function when resolved language changes. This does not change the actual behaviour of `t()` but will force `useEffect` and `useMemo` to re-run since the function itself has changed.