### PR TITLE
feat: add server-side pagination mode option to DataTable

### DIFF
--- a/src/components/DataTable/DataTable.stories.tsx
+++ b/src/components/DataTable/DataTable.stories.tsx
@@ -1,9 +1,9 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { toBasicISOString } from '@douglasneuroinformatics/libjs';
 import { faker } from '@faker-js/faker';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import type { ColumnDef } from '@tanstack/table-core';
+import type { ColumnDef, PaginationState, SortingState } from '@tanstack/table-core';
 import { range } from 'lodash-es';
 import { ChevronDownIcon } from 'lucide-react';
 
@@ -119,14 +119,12 @@ const Toggles = () => {
   );
 };
 
-export default {
-  component: DataTable
-} as Meta<typeof DataTable>;
+export default { component: DataTable } as Meta<typeof DataTable>;
 
 export const Default: Story = {
   decorators: [
     (Story) => {
-      const [tableData, setTableData] = useState(createData(10));
+      const [tableData, setTableData] = useState(createData(100));
       return (
         <div>
           <Story
@@ -142,7 +140,7 @@ export const Default: Story = {
             <button
               className="rounded-md border px-2 py-1.5 text-sm"
               type="button"
-              onClick={() => setTableData(createData(10))}
+              onClick={() => setTableData(createData(100))}
             >
               New Data
             </button>
@@ -288,4 +286,58 @@ export const Grouped: Story = {
       }
     ]
   }
+};
+
+export const Server: Story = {
+  decorators: [
+    (Story) => {
+      const allServerData = useMemo<Payment[]>(() => {
+        return range(100).map((i) => ({
+          amount: faker.number.int({ max: 100, min: 0 }),
+          date: faker.date.recent(),
+          email: faker.internet.email(),
+          id: String(i + 1),
+          status: faker.helpers.arrayElement(statuses)
+        }));
+      }, []);
+
+      const [pagination, setPagination] = useState<PaginationState>({ pageIndex: 0, pageSize: 10 });
+      const [sorting, setSorting] = useState<SortingState>([]);
+
+      const sortedData = useMemo(() => {
+        if (!sorting.length) {
+          return allServerData;
+        }
+        const { desc, id } = sorting[0]!;
+        return [...allServerData].sort((a, b) => {
+          const aVal = a[id as keyof Payment];
+          const bVal = b[id as keyof Payment];
+          if (aVal < bVal) {
+            return desc ? 1 : -1;
+          } else if (aVal > bVal) {
+            return desc ? -1 : 1;
+          }
+          return 0;
+        });
+      }, [allServerData, sorting]);
+
+      const pageData = sortedData.slice(
+        pagination.pageIndex * pagination.pageSize,
+        (pagination.pageIndex + 1) * pagination.pageSize
+      );
+
+      return (
+        <Story
+          args={{
+            columns,
+            data: pageData,
+            mode: 'server',
+            onPaginationChange: setPagination,
+            onSortingChange: setSorting,
+            pageCount: Math.ceil(allServerData.length / pagination.pageSize)
+          }}
+        />
+      );
+    }
+  ]
 };

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -36,4 +36,11 @@ export const DataTable = <T extends RowData>({
   );
 };
 
+export type {
+  DataTableColumnBreakpoints,
+  DataTableProps,
+  DataTableRowAction,
+  DataTableSearchChangeHandler
+} from './types.ts';
+
 export * as TanstackTable from '@tanstack/table-core';

--- a/src/components/DataTable/DataTableControls.tsx
+++ b/src/components/DataTable/DataTableControls.tsx
@@ -7,13 +7,13 @@ import { useTranslation } from '#hooks';
 import { SearchBar } from '../SearchBar/SearchBar.tsx';
 import { useDataTableHandle, useDataTableStore } from './hooks.ts';
 
-import type { SearchChangeHandler } from './types.ts';
+import type { DataTableSearchChangeHandler } from './types.ts';
 
 export const DataTableControls = <T extends RowData>({
   onSearchChange,
   togglesComponent: Toggles
 }: {
-  onSearchChange?: SearchChangeHandler<T>;
+  onSearchChange?: DataTableSearchChangeHandler<T>;
   togglesComponent?: React.FC<{ table: Table<T> }>;
 }) => {
   const table = useDataTableHandle('table');

--- a/src/components/DataTable/store.ts
+++ b/src/components/DataTable/store.ts
@@ -5,7 +5,7 @@ import {
   getPaginationRowModel,
   getSortedRowModel
 } from '@tanstack/table-core';
-import type { GlobalFilter, TableState, Updater } from '@tanstack/table-core';
+import type { GlobalFilter, TableOptionsResolved, TableState, Updater } from '@tanstack/table-core';
 import { createStore } from 'zustand';
 
 import { ROW_ACTIONS_METADATA_KEY, TABLE_NAME_METADATA_KEY } from './constants.ts';
@@ -67,15 +67,33 @@ export function createDataTableStore<T>(params: DataTableStoreParams<T>) {
       });
     };
 
+    // Mutable refs for server callbacks; updated by reset() as props change so handlers always call the latest version
+    let _serverOnPaginationChange = params.mode === 'server' ? params.onPaginationChange : undefined;
+    let _serverOnSortingChange = params.mode === 'server' ? params.onSortingChange : undefined;
+
+    let modeOptions: Partial<TableOptionsResolved<any>>;
+    if (params.mode === 'server') {
+      modeOptions = {
+        manualFiltering: true,
+        manualPagination: true,
+        manualSorting: true,
+        pageCount: params.pageCount
+      };
+    } else {
+      modeOptions = {
+        getFilteredRowModel: getFilteredRowModel(),
+        getPaginationRowModel: getPaginationRowModel(),
+        getSortedRowModel: getSortedRowModel()
+      };
+    }
+
     const table = createTable<any>({
+      ...modeOptions,
       columnResizeMode: 'onChange',
       columns: getColumnsWithActions(params),
       data: params.data,
       enableSortingRemoval: false,
       getCoreRowModel: getCoreRowModel(),
-      getFilteredRowModel: getFilteredRowModel(),
-      getPaginationRowModel: getPaginationRowModel(),
-      getSortedRowModel: getSortedRowModel(),
       meta: {
         ...params.meta,
         [ROW_ACTIONS_METADATA_KEY]: params.rowActions,
@@ -128,10 +146,12 @@ export function createDataTableStore<T>(params: DataTableStoreParams<T>) {
       },
       onPaginationChange: (updaterOrValue) => {
         setTableState('pagination', updaterOrValue);
+        _serverOnPaginationChange?.(table.getState().pagination);
         invalidateHandles();
       },
       onSortingChange: (updaterOrValue) => {
         setTableState('sorting', updaterOrValue);
+        _serverOnSortingChange?.(table.getState().sorting);
         invalidateHandles();
       },
       onStateChange: (updaterOrValue) => {
@@ -166,18 +186,34 @@ export function createDataTableStore<T>(params: DataTableStoreParams<T>) {
       },
       _containerWidth: null,
       _key: Symbol(),
-      reset: (params) => {
-        table.setOptions((options) => ({
-          ...options,
-          columns: getColumnsWithActions(params),
-          data: params.data,
-          meta: {
-            ...params.meta,
-            [ROW_ACTIONS_METADATA_KEY]: params.rowActions,
-            [TABLE_NAME_METADATA_KEY]: params.tableName
-          },
-          state: getTanstackTableState(params)
-        }));
+      reset: (updatedParams) => {
+        if (updatedParams.mode === 'server') {
+          _serverOnPaginationChange = updatedParams.onPaginationChange;
+          _serverOnSortingChange = updatedParams.onSortingChange;
+          table.setOptions((options) => ({
+            ...options,
+            columns: getColumnsWithActions(updatedParams),
+            data: updatedParams.data,
+            meta: {
+              ...updatedParams.meta,
+              [ROW_ACTIONS_METADATA_KEY]: updatedParams.rowActions,
+              [TABLE_NAME_METADATA_KEY]: updatedParams.tableName
+            },
+            pageCount: updatedParams.pageCount
+          }));
+        } else {
+          table.setOptions((options) => ({
+            ...options,
+            columns: getColumnsWithActions(updatedParams),
+            data: updatedParams.data,
+            meta: {
+              ...updatedParams.meta,
+              [ROW_ACTIONS_METADATA_KEY]: updatedParams.rowActions,
+              [TABLE_NAME_METADATA_KEY]: updatedParams.tableName
+            },
+            state: getTanstackTableState(updatedParams)
+          }));
+        }
         invalidateHandles();
       },
       setContainerWidth: (containerWidth) => {

--- a/src/components/DataTable/types.ts
+++ b/src/components/DataTable/types.ts
@@ -6,13 +6,14 @@ import type {
   ColumnPinningState,
   GlobalFilter,
   HeaderGroup,
+  PaginationState,
   Row,
   RowData,
   SortingState,
   Table,
   TableMeta
 } from '@tanstack/table-core';
-import type { Promisable } from 'type-fest';
+import type { Promisable, Simplify } from 'type-fest';
 
 import type { MEMOIZED_HANDLE_ID, ROW_ACTIONS_METADATA_KEY, TABLE_NAME_METADATA_KEY } from './constants.ts';
 import type { DataTableEmptyStateProps } from './DataTableEmptyState.tsx';
@@ -38,6 +39,19 @@ declare module '@tanstack/table-core' {
   }
 }
 
+/*********************************************************************
+ * BASE
+ *********************************************************************/
+
+export type BaseDataTableStoreParams<T extends RowData> = {
+  columnBreakpoints?: DataTableColumnBreakpoints;
+  columns: ColumnDef<NoInfer<T>>[];
+  data: T[];
+  meta?: TableMeta<NoInfer<T>>;
+  rowActions?: DataTableRowAction<NoInfer<T>>[];
+  tableName?: string;
+};
+
 export type DataTableColumnBreakpoints = {
   0: number;
   512: number;
@@ -46,19 +60,11 @@ export type DataTableColumnBreakpoints = {
   1280: number;
 };
 
-export type DataTableInitialState = {
-  columnFilters?: ColumnFiltersState;
-  columnPinning?: ColumnPinningState;
-  sorting?: SortingState;
-};
-
-export type DataTableProps<T extends RowData> = DataTableContentProps<T> & DataTableStoreParams<T>;
-
 export type DataTableContentProps<T extends RowData> = {
   emptyStateProps?: Partial<DataTableEmptyStateProps>;
   onRowClick?: (row: T) => Promisable<void>;
   onRowDoubleClick?: (row: T) => Promisable<void>;
-  onSearchChange?: SearchChangeHandler<NoInfer<T>>;
+  onSearchChange?: DataTableSearchChangeHandler<NoInfer<T>>;
   togglesComponent?: React.FC<{ table: Table<T> }>;
 };
 
@@ -72,6 +78,60 @@ export type DataTableRowAction<T extends RowData> = {
   label: string;
   onSelect: (row: T, table: Table<T>) => Promisable<void>;
 };
+
+export type DataTableSearchChangeHandler<T = any> = (value: string, table: Table<T>) => void;
+
+export type MemoizedHandle<T extends (...args: any[]) => any> = T & {
+  invalidate(): void;
+  [MEMOIZED_HANDLE_ID]: symbol;
+};
+
+/*********************************************************************
+ * CLIENT
+ *********************************************************************/
+
+export type ClientDataTableInitialState = {
+  columnFilters?: ColumnFiltersState;
+  columnPinning?: ColumnPinningState;
+  sorting?: SortingState;
+};
+
+export type ClientDataTableStoreParams<T extends RowData> = Simplify<
+  BaseDataTableStoreParams<T> & {
+    initialState?: ClientDataTableInitialState;
+    mode?: 'client';
+  }
+>;
+
+export type ClientDataTableProps<T extends RowData> = Simplify<
+  ClientDataTableStoreParams<T> & DataTableContentProps<T>
+>;
+
+/*********************************************************************
+ * SERVER
+ *********************************************************************/
+
+export type ServerDataTableStoreParams<T extends RowData> = Simplify<
+  BaseDataTableStoreParams<T> & {
+    initialState?: never;
+    mode: 'server';
+    onPaginationChange: (state: PaginationState) => void;
+    onSortingChange?: (state: SortingState) => void;
+    pageCount: number;
+  }
+>;
+
+export type ServerDataTableProps<T extends RowData> = DataTableContentProps<T> & ServerDataTableStoreParams<T>;
+
+/*********************************************************************
+ * COMMON
+ *********************************************************************/
+
+export type DataTableStoreParams<T extends RowData = any> =
+  | ClientDataTableStoreParams<T>
+  | ServerDataTableStoreParams<T>;
+
+export type DataTableProps<T extends RowData = any> = ClientDataTableProps<T> | ServerDataTableProps<T>;
 
 export type DataTableStore = {
   $handles: DataTableHandles<{
@@ -87,26 +147,9 @@ export type DataTableStore = {
   }>;
   _containerWidth: null | number;
   _key: symbol;
-  reset: (params: DataTableStoreParams<any>) => void;
+  reset: (params: DataTableStoreParams) => void;
   setContainerWidth: (containerWidth: number) => void;
   setGlobalFilter: (globalFilter: GlobalFilter) => void;
   setPageIndex: (index: number) => void;
   style: React.CSSProperties;
 };
-
-export type DataTableStoreParams<T extends RowData> = {
-  columnBreakpoints?: DataTableColumnBreakpoints;
-  columns: ColumnDef<NoInfer<T>>[];
-  data: T[];
-  initialState?: DataTableInitialState;
-  meta?: TableMeta<NoInfer<T>>;
-  rowActions?: DataTableRowAction<NoInfer<T>>[];
-  tableName?: string;
-};
-
-export type MemoizedHandle<T extends (...args: any[]) => any> = T & {
-  invalidate(): void;
-  [MEMOIZED_HANDLE_ID]: symbol;
-};
-
-export type SearchChangeHandler<T = any> = (value: string, table: Table<T>) => void;

--- a/src/components/DataTable/utils.tsx
+++ b/src/components/DataTable/utils.tsx
@@ -4,7 +4,12 @@ import { sum } from 'lodash-es';
 import { ACTIONS_COLUMN_ID, MEMOIZED_HANDLE_ID } from './constants.ts';
 import { DataTableRowActionCell } from './DataTableRowActionCell.tsx';
 
-import type { DataTableColumnBreakpoints, DataTableStoreParams, MemoizedHandle } from './types.ts';
+import type {
+  BaseDataTableStoreParams,
+  DataTableColumnBreakpoints,
+  DataTableStoreParams,
+  MemoizedHandle
+} from './types.ts';
 
 const DEFAULT_COLUMN_BREAKPOINTS: DataTableColumnBreakpoints = {
   0: 1,
@@ -86,7 +91,10 @@ function flexRender<TProps extends object>(
   return !Comp ? null : isReactComponent<TProps>(Comp) ? <Comp {...props} /> : Comp;
 }
 
-function getColumnsWithActions<T extends RowData>({ columns, rowActions }: DataTableStoreParams<T>): ColumnDef<T>[] {
+function getColumnsWithActions<T extends RowData>({
+  columns,
+  rowActions
+}: BaseDataTableStoreParams<T>): ColumnDef<T>[] {
   if (!rowActions) {
     return columns;
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server-side mode to DataTable, enabling server-controlled pagination and sorting with custom callbacks.

* **Tests**
  * Added a new story demonstrating DataTable in server mode with server-side behavior emulation; increased test dataset size from 10 to 100 records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->