### PR TITLE
fix: preserve data table state across prop updates

### DIFF
--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -20,10 +20,29 @@ export const DataTable = <T extends RowData>({
 }: DataTableProps<T>) => {
   const storeRef = useRef(createDataTableStore(props));
 
+  const { columnBreakpoints, columns, data, meta, mode, rowActions, tableName } = props;
+  const pageCount = props.mode === 'server' ? props.pageCount : undefined;
+  const onPaginationChange = props.mode === 'server' ? props.onPaginationChange : undefined;
+  const onSortingChange = props.mode === 'server' ? props.onSortingChange : undefined;
+
   useEffect(() => {
     const { reset } = storeRef.current.getState();
     reset(props);
-  }, [props]);
+    // Depends on the individual values `reset` consumes rather than on `props`, which is a fresh
+    // rest-spread object on every render and would therefore reset the store on every render.
+    // `initialState` is deliberately absent: it is applied once, when the store is created.
+  }, [
+    columnBreakpoints,
+    columns,
+    data,
+    meta,
+    mode,
+    onPaginationChange,
+    onSortingChange,
+    pageCount,
+    rowActions,
+    tableName
+  ]);
 
   return (
     <DataTableContext.Provider value={{ store: storeRef.current }}>

--- a/src/components/DataTable/__tests__/DataTable.spec.tsx
+++ b/src/components/DataTable/__tests__/DataTable.spec.tsx
@@ -1,8 +1,10 @@
+import { useState } from 'react';
+
 import { faker } from '@faker-js/faker';
 import type { ColumnDef } from '@tanstack/table-core';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { range } from 'lodash-es';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { DataTable } from '../DataTable.tsx';
 
@@ -64,5 +66,58 @@ describe('DataTable', () => {
     await waitFor(() => expect(screen.getAllByTestId('data-table-row').length).toBe(1));
     fireEvent.change(searchBar, { target: { value: '' } });
     await waitFor(() => expect(screen.getAllByTestId('data-table-row').length).toBe(10));
+  });
+
+  describe('state preservation across re-renders', () => {
+    // A parent that re-renders for its own reasons, passing columns and row actions inline the way
+    // call sites normally do -- so both reach the table with a fresh identity on every render.
+    const Wrapper = ({ rows = data }: { rows?: Payment[] }) => {
+      const [, setTick] = useState(0);
+      return (
+        <div>
+          <button onClick={() => setTick((value) => value + 1)}>Re-render</button>
+          <DataTable columns={[...columns]} data={rows} rowActions={[{ label: 'View', onSelect: vi.fn() }]} />
+        </div>
+      );
+    };
+
+    const goToPage = (page: number) => fireEvent.click(screen.getByRole('button', { name: String(page) }));
+    const reRenderParent = () => fireEvent.click(screen.getByText('Re-render'));
+    const firstVisibleRow = () => screen.getAllByTestId('data-table-row')[0]!;
+
+    it('should keep the current page when the parent re-renders', () => {
+      render(<Wrapper />);
+      goToPage(2);
+      // With the default page size of 10, page two starts at the eleventh record.
+      expect(firstVisibleRow()).toHaveTextContent(data[10]!.email);
+
+      reRenderParent();
+
+      expect(firstVisibleRow()).toHaveTextContent(data[10]!.email);
+    });
+
+    it('should keep the global filter when the parent re-renders', async () => {
+      render(<Wrapper />);
+      const searchBar = screen.getByTestId('data-table-search-bar').querySelector('input')!;
+      fireEvent.change(searchBar, { target: { value: data[0]!.email } });
+      await waitFor(() => expect(screen.getAllByTestId('data-table-row').length).toBe(1));
+
+      reRenderParent();
+
+      await waitFor(() => expect(screen.getAllByTestId('data-table-row').length).toBe(1));
+      expect(searchBar.value).toBe(data[0]!.email);
+    });
+
+    it('should clamp to the last page when new data no longer reaches the current one', () => {
+      const { rerender } = render(<Wrapper />);
+      goToPage(2);
+
+      rerender(<Wrapper rows={data.slice(0, 3)} />);
+
+      // Only one page of three rows is left, so page two no longer exists and we fall back to the
+      // last page that does, rather than sitting on an empty one.
+      expect(screen.getAllByTestId('data-table-row').length).toBe(3);
+      expect(firstVisibleRow()).toHaveTextContent(data[0]!.email);
+    });
   });
 });

--- a/src/components/DataTable/store.ts
+++ b/src/components/DataTable/store.ts
@@ -13,6 +13,7 @@ import {
   applyUpdater,
   calculateColumnSizing,
   defineMemoizedHandle,
+  getColumnPinningWithActions,
   getColumnsWithActions,
   getTanstackTableState
 } from './utils.tsx';
@@ -187,33 +188,44 @@ export function createDataTableStore<T>(params: DataTableStoreParams<T>) {
       _containerWidth: null,
       _key: Symbol(),
       reset: (updatedParams) => {
+        const isServer = updatedParams.mode === 'server';
         if (updatedParams.mode === 'server') {
           _serverOnPaginationChange = updatedParams.onPaginationChange;
           _serverOnSortingChange = updatedParams.onSortingChange;
-          table.setOptions((options) => ({
-            ...options,
-            columns: getColumnsWithActions(updatedParams),
-            data: updatedParams.data,
-            meta: {
-              ...updatedParams.meta,
-              [ROW_ACTIONS_METADATA_KEY]: updatedParams.rowActions,
-              [TABLE_NAME_METADATA_KEY]: updatedParams.tableName
-            },
-            pageCount: updatedParams.pageCount
-          }));
-        } else {
-          table.setOptions((options) => ({
-            ...options,
-            columns: getColumnsWithActions(updatedParams),
-            data: updatedParams.data,
-            meta: {
-              ...updatedParams.meta,
-              [ROW_ACTIONS_METADATA_KEY]: updatedParams.rowActions,
-              [TABLE_NAME_METADATA_KEY]: updatedParams.tableName
-            },
-            state: getTanstackTableState(updatedParams)
-          }));
         }
+        table.setOptions((options) => ({
+          ...options,
+          columns: getColumnsWithActions(updatedParams),
+          data: updatedParams.data,
+          meta: {
+            ...updatedParams.meta,
+            [ROW_ACTIONS_METADATA_KEY]: updatedParams.rowActions,
+            [TABLE_NAME_METADATA_KEY]: updatedParams.tableName
+          },
+          ...(updatedParams.mode === 'server' && { pageCount: updatedParams.pageCount })
+        }));
+
+        // `initialState` is applied once, when the store is created. Everything in the live table
+        // state -- pagination, sorting, column filters, the global filter, column sizing -- is owned
+        // by the user, not by props, so rebuilding it here would send them back to page one (losing
+        // their sort and search along with it) every time `data` or `columns` changed identity. The
+        // only piece of state derived from props is the actions column's pinning, so reconcile just
+        // that.
+        setTableState('columnPinning', (columnPinning) =>
+          getColumnPinningWithActions(columnPinning, updatedParams.rowActions)
+        );
+
+        // A props update can shrink the data out from under the current page (a consumer applying a
+        // filter, say). Clamp to the last page that still exists rather than resetting to the first,
+        // so the user keeps their place whenever it survives. Server mode owns its own pagination.
+        if (!isServer) {
+          const pageCount = table.getPageCount();
+          const { pageIndex } = table.getState().pagination;
+          if (pageCount > 0 && pageIndex > pageCount - 1) {
+            table.setPageIndex(pageCount - 1);
+          }
+        }
+
         updateColumnSizing();
         updateStyle();
         invalidateHandles();

--- a/src/components/DataTable/utils.tsx
+++ b/src/components/DataTable/utils.tsx
@@ -1,4 +1,12 @@
-import type { ColumnDef, ColumnSizingState, RowData, Table, TableState, Updater } from '@tanstack/table-core';
+import type {
+  ColumnDef,
+  ColumnPinningState,
+  ColumnSizingState,
+  RowData,
+  Table,
+  TableState,
+  Updater
+} from '@tanstack/table-core';
 import { sum } from 'lodash-es';
 
 import { ACTIONS_COLUMN_ID, MEMOIZED_HANDLE_ID } from './constants.ts';
@@ -7,6 +15,7 @@ import { DataTableRowActionCell } from './DataTableRowActionCell.tsx';
 import type {
   BaseDataTableStoreParams,
   DataTableColumnBreakpoints,
+  DataTableRowAction,
   DataTableStoreParams,
   MemoizedHandle
 } from './types.ts';
@@ -110,6 +119,22 @@ function getColumnsWithActions<T extends RowData>({
   ];
 }
 
+/**
+ * The given column pinning, with the actions column pinned to the right if (and only if) the table
+ * has row actions. Pinning is the one part of the table state derived from props, so it must be
+ * reconcilable on a props update without disturbing the rest of the user's pinning.
+ */
+function getColumnPinningWithActions<T extends RowData>(
+  columnPinning: ColumnPinningState,
+  rowActions: DataTableRowAction<T>[] | undefined
+): ColumnPinningState {
+  const right = (columnPinning.right ?? []).filter((id) => id !== ACTIONS_COLUMN_ID);
+  return {
+    ...columnPinning,
+    right: rowActions ? [...right, ACTIONS_COLUMN_ID] : right
+  };
+}
+
 function getTanstackTableState<T>({ initialState, rowActions }: DataTableStoreParams<T>): TableState {
   const { columnFilters = [], columnPinning = {}, sorting = [] } = initialState ?? {};
   const state: TableState = {
@@ -137,12 +162,7 @@ function getTanstackTableState<T>({ initialState, rowActions }: DataTableStorePa
     rowSelection: {},
     sorting
   };
-  if (rowActions) {
-    state.columnPinning = {
-      ...state.columnPinning,
-      right: [...(state.columnPinning.right ?? []), ACTIONS_COLUMN_ID]
-    };
-  }
+  state.columnPinning = getColumnPinningWithActions(state.columnPinning, rowActions);
   return state;
 }
 
@@ -155,6 +175,7 @@ export {
   calculateColumnSizing,
   defineMemoizedHandle,
   flexRender,
+  getColumnPinningWithActions,
   getColumnsWithActions,
   getTanstackTableState
 };


### PR DESCRIPTION
## Problem

Paginating, sorting or searching a `DataTable` was undone as soon as the parent re-rendered, sending the user back to page one and losing their sort and search along with it.

Two defects combined to cause it:

1. **`DataTable.tsx`** reset the store from `useEffect(..., [props])`, but `props` is a fresh rest-spread object on every render — so the effect ran on *every* render.
2. **`store.ts`** — the client branch of `reset` then replaced the whole table state with `getTanstackTableState(updatedParams)`, rebuilding it from `initialState` defaults and discarding pagination, sorting, column filters, the global filter and column sizing. The server branch never did this; it only updated columns/data/meta/pageCount.

## Fix

Fixing only the effect would not have been enough — call sites normally pass `columns` and `rowActions` as inline literals, so those change identity every render regardless. Defect 2 is the load-bearing one.

- `reset` no longer touches live table state, which also aligns the client branch with the server branch. `initialState` is applied once, when the store is created — as the name implies.
- The effect now depends on the individual values `reset` consumes rather than on the `props` object, so unrelated prop churn no longer resets anything.
- **Column pinning** is the one part of the state genuinely derived from props (the actions column pins right when `rowActions` is set), so it is reconciled on its own via a new `getColumnPinningWithActions`, shared with `getTanstackTableState` so the two definitions cannot drift.
- **Out-of-range pages:** resetting to page zero was accidentally masking these. Now that the page index survives, a props update that shrinks the data clamps to the last page that still exists rather than leaving the user on an empty one. Client mode only — calling `setPageIndex` in server mode would fire the consumer's `onPaginationChange` from inside an effect.

## Testing

Three regression tests in `DataTable.spec.tsx`, using a wrapper that re-renders for its own reasons and passes `columns`/`rowActions` inline, the way real call sites do.

I verified these actually catch the bug: with the test file kept and the source changes reverted, **the page-preservation and global-filter-preservation tests fail**. The third (clamping) passes on the old code too — resetting to page zero coincidentally showed the right rows — so it guards the new behaviour rather than reproducing the old bug.

`pnpm lint` clean, full suite 36 files / 177 tests pass, `pnpm build` succeeds.

## Downstream

Open Data Capture currently works around this by memoizing the `DataTable` element at five call sites and routing a row highlight through React context, plus a couple of `useRef` shims to keep values out of the memo dependency lists. Once this releases, that can be unwound.