### PR TITLE
fix: preserve data table state across prop updates

### DIFF
--- a/src/components/DataTable/DataTableControls.tsx
+++ b/src/components/DataTable/DataTableControls.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import type { RowData, Table } from '@tanstack/table-core';
 
@@ -22,14 +22,22 @@ export const DataTableControls = <T extends RowData>({
 
   const { t } = useTranslation();
 
+  // Held in a ref so that the effect below responds to the search value alone. Call sites normally
+  // write `onSearchChange` inline, so it is a new function on every render; keying the effect on it
+  // replayed the handler on every render of the consumer, and a handler that writes filter state
+  // then reset the table's page via Tanstack's `autoResetPageIndex`.
+  const onSearchChangeRef = useRef(onSearchChange);
+  onSearchChangeRef.current = onSearchChange;
+
   useEffect(() => {
-    if (onSearchChange) {
+    const handleSearchChange = onSearchChangeRef.current;
+    if (handleSearchChange) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      onSearchChange(searchValue, table);
+      handleSearchChange(searchValue, table);
     } else {
       setGlobalFilter(searchValue || undefined);
     }
-  }, [onSearchChange, searchValue]);
+  }, [searchValue]);
 
   return (
     <div className="flex flex-col items-center gap-4 pb-4 md:flex-row">

--- a/src/components/DataTable/__tests__/DataTable.spec.tsx
+++ b/src/components/DataTable/__tests__/DataTable.spec.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import { faker } from '@faker-js/faker';
 import type { ColumnDef } from '@tanstack/table-core';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
@@ -5,6 +7,8 @@ import { range } from 'lodash-es';
 import { describe, expect, it } from 'vitest';
 
 import { DataTable } from '../DataTable.tsx';
+
+import type { DataTableSearchChangeHandler } from '../types.ts';
 
 type PaymentStatus = 'failed' | 'pending' | 'processing' | 'success';
 
@@ -64,5 +68,87 @@ describe('DataTable', () => {
     await waitFor(() => expect(screen.getAllByTestId('data-table-row').length).toBe(1));
     fireEvent.change(searchBar, { target: { value: '' } });
     await waitFor(() => expect(screen.getAllByTestId('data-table-row').length).toBe(10));
+  });
+});
+
+describe('DataTable pagination', () => {
+  // Deterministic, so a row can be identified by the page it belongs to
+  const paginatedData: Payment[] = range(25).map((i) => ({
+    amount: i,
+    email: `user-${i + 1}@example.com`,
+    id: String(i + 1),
+    status: 'pending'
+  }));
+
+  const firstRow = () => screen.getAllByTestId('data-table-row')[0]!;
+
+  const goToSecondPage = async () => {
+    fireEvent.click(screen.getByRole('button', { name: '2' }));
+    await waitFor(() => expect(firstRow()).toHaveTextContent('user-11@example.com'));
+  };
+
+  /**
+   * Records the clicked row, the way a consumer would in order to highlight it. The point is that
+   * this is an ordinary `setState` in the component that owns the table: it re-renders the
+   * consumer, but changes nothing about the table's contents.
+   */
+  const ClickToSelect = ({ onSearchChange }: { onSearchChange?: DataTableSearchChangeHandler<Payment> }) => {
+    const [clickedRowId, setClickedRowId] = useState<null | string>(null);
+    return (
+      <div>
+        <span data-testid="clicked-row-id">{clickedRowId ?? 'none'}</span>
+        <DataTable
+          columns={columns}
+          data={paginatedData}
+          onRowClick={(payment) => setClickedRowId(payment.id)}
+          onSearchChange={onSearchChange}
+        />
+      </div>
+    );
+  };
+
+  it('should stay on the current page when a row click re-renders the consumer', async () => {
+    render(<ClickToSelect />);
+    await goToSecondPage();
+
+    fireEvent.click(firstRow());
+    await waitFor(() => expect(screen.getByTestId('clicked-row-id')).toHaveTextContent('11'));
+
+    expect(firstRow()).toHaveTextContent('user-11@example.com');
+  });
+
+  // `DataTableControls` runs `onSearchChange` from an effect keyed on the handler itself, so an
+  // inline handler -- the normal way to write one -- re-runs it on every consumer render, not only
+  // when the search value changes. A handler that writes filter state then hands Tanstack a new
+  // `columnFilters` identity, whose `autoResetPageIndex` returns the table to the first page.
+  it('should stay on the current page when an inline onSearchChange writes filter state', async () => {
+    render(
+      <ClickToSelect
+        onSearchChange={(_, table) => {
+          table.getColumn('status')!.setFilterValue(() => [...statuses]);
+        }}
+      />
+    );
+    await goToSecondPage();
+
+    fireEvent.click(firstRow());
+    await waitFor(() => expect(screen.getByTestId('clicked-row-id')).toHaveTextContent('11'));
+
+    expect(firstRow()).toHaveTextContent('user-11@example.com');
+  });
+
+  // Same reset, seen from the search box: the filter is dropped from the table state while the
+  // search input keeps its text, so the controls end up contradicting the rows
+  it('should keep the search applied when a row click re-renders the consumer', async () => {
+    render(<ClickToSelect />);
+    const searchBar = screen.getByTestId('data-table-search-bar').querySelector('input')!;
+    fireEvent.change(searchBar, { target: { value: 'user-11@example.com' } });
+    await waitFor(() => expect(screen.getAllByTestId('data-table-row').length).toBe(1));
+
+    fireEvent.click(firstRow());
+    await waitFor(() => expect(screen.getByTestId('clicked-row-id')).toHaveTextContent('11'));
+
+    expect(searchBar).toHaveValue('user-11@example.com');
+    expect(screen.getAllByTestId('data-table-row').length).toBe(1);
   });
 });

--- a/src/components/DataTable/store.ts
+++ b/src/components/DataTable/store.ts
@@ -13,6 +13,7 @@ import {
   applyUpdater,
   calculateColumnSizing,
   defineMemoizedHandle,
+  getColumnPinningWithActions,
   getColumnsWithActions,
   getTanstackTableState
 } from './utils.tsx';
@@ -190,30 +191,29 @@ export function createDataTableStore<T>(params: DataTableStoreParams<T>) {
         if (updatedParams.mode === 'server') {
           _serverOnPaginationChange = updatedParams.onPaginationChange;
           _serverOnSortingChange = updatedParams.onSortingChange;
-          table.setOptions((options) => ({
-            ...options,
-            columns: getColumnsWithActions(updatedParams),
-            data: updatedParams.data,
-            meta: {
-              ...updatedParams.meta,
-              [ROW_ACTIONS_METADATA_KEY]: updatedParams.rowActions,
-              [TABLE_NAME_METADATA_KEY]: updatedParams.tableName
-            },
-            pageCount: updatedParams.pageCount
-          }));
-        } else {
-          table.setOptions((options) => ({
-            ...options,
-            columns: getColumnsWithActions(updatedParams),
-            data: updatedParams.data,
-            meta: {
-              ...updatedParams.meta,
-              [ROW_ACTIONS_METADATA_KEY]: updatedParams.rowActions,
-              [TABLE_NAME_METADATA_KEY]: updatedParams.tableName
-            },
-            state: getTanstackTableState(updatedParams)
-          }));
         }
+        table.setOptions((options) => ({
+          ...options,
+          columns: getColumnsWithActions(updatedParams),
+          data: updatedParams.data,
+          meta: {
+            ...updatedParams.meta,
+            [ROW_ACTIONS_METADATA_KEY]: updatedParams.rowActions,
+            [TABLE_NAME_METADATA_KEY]: updatedParams.tableName
+          },
+          ...(updatedParams.mode === 'server' && { pageCount: updatedParams.pageCount })
+        }));
+
+        // `initialState` is applied once, when the store is created. Everything in the live table
+        // state -- pagination, sorting, column filters, the global filter, column sizing -- is
+        // owned by the user, not by props, so rebuilding it here would send them back to page one
+        // (losing their sort and search along with it) every time `data` or `columns` changed
+        // identity. The only piece derived from props is the actions column's pinning, so
+        // reconcile just that.
+        setTableState('columnPinning', (columnPinning) =>
+          getColumnPinningWithActions(columnPinning, updatedParams.rowActions)
+        );
+
         updateColumnSizing();
         updateStyle();
         invalidateHandles();

--- a/src/components/DataTable/utils.tsx
+++ b/src/components/DataTable/utils.tsx
@@ -1,4 +1,12 @@
-import type { ColumnDef, ColumnSizingState, RowData, Table, TableState, Updater } from '@tanstack/table-core';
+import type {
+  ColumnDef,
+  ColumnPinningState,
+  ColumnSizingState,
+  RowData,
+  Table,
+  TableState,
+  Updater
+} from '@tanstack/table-core';
 import { sum } from 'lodash-es';
 
 import { ACTIONS_COLUMN_ID, MEMOIZED_HANDLE_ID } from './constants.ts';
@@ -7,6 +15,7 @@ import { DataTableRowActionCell } from './DataTableRowActionCell.tsx';
 import type {
   BaseDataTableStoreParams,
   DataTableColumnBreakpoints,
+  DataTableRowAction,
   DataTableStoreParams,
   MemoizedHandle
 } from './types.ts';
@@ -110,6 +119,22 @@ function getColumnsWithActions<T extends RowData>({
   ];
 }
 
+/**
+ * The given column pinning, with the actions column pinned to the right if (and only if) the table
+ * has row actions. Pinning is the one part of the table state derived from props, so it has to be
+ * reconcilable on a props update without disturbing the rest of the state.
+ */
+function getColumnPinningWithActions<T extends RowData>(
+  columnPinning: ColumnPinningState,
+  rowActions: DataTableRowAction<T>[] | undefined
+): ColumnPinningState {
+  const right = (columnPinning.right ?? []).filter((id) => id !== ACTIONS_COLUMN_ID);
+  return {
+    ...columnPinning,
+    right: rowActions ? [...right, ACTIONS_COLUMN_ID] : right
+  };
+}
+
 function getTanstackTableState<T>({ initialState, rowActions }: DataTableStoreParams<T>): TableState {
   const { columnFilters = [], columnPinning = {}, sorting = [] } = initialState ?? {};
   const state: TableState = {
@@ -137,12 +162,7 @@ function getTanstackTableState<T>({ initialState, rowActions }: DataTableStorePa
     rowSelection: {},
     sorting
   };
-  if (rowActions) {
-    state.columnPinning = {
-      ...state.columnPinning,
-      right: [...(state.columnPinning.right ?? []), ACTIONS_COLUMN_ID]
-    };
-  }
+  state.columnPinning = getColumnPinningWithActions(state.columnPinning, rowActions);
   return state;
 }
 
@@ -155,6 +175,7 @@ export {
   calculateColumnSizing,
   defineMemoizedHandle,
   flexRender,
+  getColumnPinningWithActions,
   getColumnsWithActions,
   getTanstackTableState
 };


### PR DESCRIPTION
Paginating, sorting or searching a `DataTable` was undone as soon as the consumer re-rendered. Most visibly: page to 2 and click a row, and the table jumps back to page 1. Clicking a row typically sets state to highlight it, and that re-render was enough — nothing about the table's data changed.

## Cause

Two independent causes, both required:

1. **`store.ts`** — `reset()`'s client branch set `state: getTanstackTableState(updatedParams)`, which builds a `TableState` from scratch (`pageIndex: 0`, empty sizing, `initialState` filters and sorting). Every call replaced pagination, sorting, filters and column sizing with props-time defaults. `DataTable` keys its effect on `[props]`, a fresh rest-spread object each render, so this ran on *every* render. The server branch never did this.

2. **`DataTableControls.tsx`** — the effect was keyed on `[onSearchChange, searchValue]`. Callers write `onSearchChange` inline, so it is a new function every render and the effect replayed the handler with an unchanged search value. A handler that writes filter state (the common shape, `setFilterValue(prev => ({ ...prev, searchString }))`) then handed Tanstack a new `columnFilters` identity, tripping `autoResetPageIndex`.

Cause 2 is why the earlier fix (976be28, released as 6.9.2) looked ineffective and was reverted — it addressed only cause 1, so row clicks still reset the page in any table using `onSearchChange`.

## Change

- **`store.ts`** — `reset()` no longer touches live table state. One `setOptions` call for both modes updates the genuine inputs (`columns`, `data`, `meta`, plus `pageCount` for server mode). `initialState` now applies once, at store creation.
- **`utils.tsx`** — extracted `getColumnPinningWithActions`. Column pinning is the one slice of state derived from props, so `reset` reconciles just that via a `setTableState` updater; sharing the helper with `getTanstackTableState` keeps the create and update paths from drifting.
- **`DataTableControls.tsx`** — the handler is held in a ref so the effect is keyed on `searchValue` alone. Mount-time invocation is unchanged.

Memoizing `columns` is not an alternative: `cell` closures capture consumer state, so `columns` is legitimately new each render and skipping the update would leave stale cells rendering. The update was always correct; only its side effect on state was wrong.

## Behaviour changes

- **`columnVisibility` now persists.** Previously any consumer re-render restored all columns to visible, so `togglesComponent` selections were silently reverted. They now stick.
- **`initialState` is now genuinely initial.** Changes to it after mount are ignored. Previously prop-time `columnFilters` / `sorting` were reapplied on every render.
- Dropping `rowActions` now unpins the actions column in **server** mode too; the old server branch never reconciled pinning.

## Columns changing under us

Verified safe against `@tanstack/table-core@8.21.3` — every column-keyed state slice tolerates ids that no longer exist:

- `getSortedRowModel.ts:22` — filters out sortings for non-existent columns
- `getFilteredRowModel.ts:32` — `if (!column) return`
- `ColumnPinning.ts:302-320` — `.map(...).filter(Boolean)` on left/right/center

`columnSizing` is fully recomputed by `updateColumnSizing()` on every reset, so no stale entries survive. Removing a sorted column, removing a filtered column, and dropping `rowActions` mid-life were each exercised and behave correctly. Stale `columnFilters` / `sorting` / `columnVisibility` entries do persist for removed columns and will reapply if that column id returns — generally the desired behaviour.

## Verification

177/177 tests pass, `tsc` and `eslint` clean. Three regression tests added in `__tests__/DataTable.spec.tsx` — page survives a row click; survives it with an inline `onSearchChange` that writes filter state; search survives it — all three fail before the fix.

## Known gaps (follow-ups, not regressions)

- **Transient empty table when `data` shrinks.** On page 3 of 50 rows, swapping in 3 rows renders 0 rows for one commit before `autoResetPageIndex`'s queued microtask (`table.ts:334`) lands; `DataTableBody.tsx:20` shows the empty state at zero rows. Pre-fix it showed 3 rows immediately. A synchronous clamp to page 0 in `reset()` closes this with no semantic change, since `resetPageIndex()` lands on 0 anyway (`RowPagination.ts:273`).
- **The fix is conditional on a referentially stable `data`.** With an unmemoized array (`data={rows.map(toDisplay)}`), a row click still bounces to page 1 — `data` identity change trips `autoResetPageIndex`. This is unchanged from before and not a regression, but it limits the fix's reach. Properly addressing it means `autoResetPageIndex: false` plus explicit page-reset policy in the store, which also changes what happens when `data` is swapped wholesale — a deliberate change deserving its own PR.
- Not yet verified against a consuming app.